### PR TITLE
infra/talos cluster config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+.terraform.lock.hcl
 
 inventory.yaml
 

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ inventory.yaml
 
 root.hcl
 .terragrunt*
+
+venv

--- a/infra/talos-proxmox/bootstrap/refresh-kubeconfig.sh
+++ b/infra/talos-proxmox/bootstrap/refresh-kubeconfig.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Script to refresh kubeconfig when control plane nodes change
+# Usage: ./refresh-kubeconfig.sh
+
+echo "🔄 Refreshing kubeconfig after control plane changes..."
+
+# Taint the kubeconfig resource to force recreation
+echo "📌 Tainting kubeconfig resource..."
+terragrunt taint talos_cluster_kubeconfig.this
+
+# Taint the local kubeconfig file as well
+echo "📌 Tainting kubeconfig file..."
+terragrunt taint local_file.kubeconfig
+
+# Apply changes
+echo "🚀 Applying changes..."
+terragrunt apply
+
+echo "✅ Kubeconfig refreshed! New kubeconfig should contain updated server endpoint."

--- a/infra/talos-proxmox/bootstrap/terraform/locals.tf
+++ b/infra/talos-proxmox/bootstrap/terraform/locals.tf
@@ -7,4 +7,14 @@ locals {
   # Use cluster VIP if provided, otherwise use first control plane IP
   cluster_endpoint_ip = var.cluster_vip != "" ? var.cluster_vip : local.controlplane_ips[0]
   cluster_endpoint    = "https://${local.cluster_endpoint_ip}:6443"
+  
+  # Use specific bootstrap node IP if provided, otherwise use first available control plane
+  bootstrap_node_ip = var.bootstrap_node_ip != "" ? var.bootstrap_node_ip : local.controlplane_ips[0]
+  
+  # Hash of critical values to trigger kubeconfig recreation
+  kubeconfig_trigger = md5(join(",", [
+    local.cluster_endpoint,
+    local.bootstrap_node_ip,
+    join(",", local.controlplane_ips)
+  ]))
 }

--- a/infra/talos-proxmox/bootstrap/terraform/locals.tf
+++ b/infra/talos-proxmox/bootstrap/terraform/locals.tf
@@ -1,6 +1,10 @@
 
 locals {
-  controlplane_ip = var.controlplane_ip
+  controlplane_ips = var.controlplane_ips
   worker_ips      = var.worker_ips
-  all_nodes       = concat([local.controlplane_ip], local.worker_ips)
+  all_nodes       = concat(local.controlplane_ips, local.worker_ips)
+  
+  # Use cluster VIP if provided, otherwise use first control plane IP
+  cluster_endpoint_ip = var.cluster_vip != "" ? var.cluster_vip : local.controlplane_ips[0]
+  cluster_endpoint    = "https://${local.cluster_endpoint_ip}:6443"
 }

--- a/infra/talos-proxmox/bootstrap/terraform/main.tf
+++ b/infra/talos-proxmox/bootstrap/terraform/main.tf
@@ -17,7 +17,7 @@ resource "talos_machine_bootstrap" "this" {
   ]
   
   client_configuration = talos_machine_secrets.this.client_configuration
-  node                 = local.controlplane_ips[0]  # Bootstrap from first control plane
+  node                 = local.bootstrap_node_ip  # Use configurable bootstrap node
 }
 
 resource "talos_cluster_kubeconfig" "this" {
@@ -25,7 +25,7 @@ resource "talos_cluster_kubeconfig" "this" {
     talos_machine_bootstrap.this
   ]
   client_configuration = talos_machine_secrets.this.client_configuration
-  node                 = local.controlplane_ips[0]  # Get kubeconfig from first control plane
+  node                 = local.bootstrap_node_ip  # Use configurable bootstrap node for kubeconfig
 }
 
 resource "local_file" "kubeconfig" {

--- a/infra/talos-proxmox/bootstrap/terraform/main.tf
+++ b/infra/talos-proxmox/bootstrap/terraform/main.tf
@@ -5,7 +5,7 @@ resource "talos_machine_secrets" "this" {}
 data "talos_client_configuration" "this" {
   cluster_name         = var.cluster_name
   client_configuration = talos_machine_secrets.this.client_configuration
-  nodes                = [ local.controlplane_ip ]
+  nodes                = local.controlplane_ips
 }
 
 resource "talos_machine_bootstrap" "this" {
@@ -17,7 +17,7 @@ resource "talos_machine_bootstrap" "this" {
   ]
   
   client_configuration = talos_machine_secrets.this.client_configuration
-  node                 = local.controlplane_ip
+  node                 = local.controlplane_ips[0]  # Bootstrap from first control plane
 }
 
 resource "talos_cluster_kubeconfig" "this" {
@@ -25,7 +25,7 @@ resource "talos_cluster_kubeconfig" "this" {
     talos_machine_bootstrap.this
   ]
   client_configuration = talos_machine_secrets.this.client_configuration
-  node                 = local.controlplane_ip
+  node                 = local.controlplane_ips[0]  # Get kubeconfig from first control plane
 }
 
 resource "local_file" "kubeconfig" {

--- a/infra/talos-proxmox/bootstrap/terraform/node-control-plane.tf
+++ b/infra/talos-proxmox/bootstrap/terraform/node-control-plane.tf
@@ -7,9 +7,11 @@ data "talos_machine_configuration" "controlplane" {
 }
 
 resource "talos_machine_configuration_apply" "controlplane" {
+  count = length(local.controlplane_ips)
+  
   client_configuration        = talos_machine_secrets.this.client_configuration
   machine_configuration_input = data.talos_machine_configuration.controlplane.machine_configuration
-  node                        = local.controlplane_ip
+  node                        = local.controlplane_ips[count.index]
   config_patches = [
     yamlencode({
       machine = {

--- a/infra/talos-proxmox/bootstrap/terraform/outputs.tf
+++ b/infra/talos-proxmox/bootstrap/terraform/outputs.tf
@@ -30,3 +30,8 @@ output "controlplane_nodes" {
   description = "List of control plane node IPs"
   value       = local.controlplane_ips
 }
+
+output "bootstrap_node" {
+  description = "IP of the node used for bootstrap operations"
+  value       = local.bootstrap_node_ip
+}

--- a/infra/talos-proxmox/bootstrap/terraform/outputs.tf
+++ b/infra/talos-proxmox/bootstrap/terraform/outputs.tf
@@ -20,3 +20,13 @@ output "ca_certificate" {
   value       = talos_machine_secrets.this.client_configuration.ca_certificate
   sensitive   = true
 }
+
+output "cluster_endpoint" {
+  description = "Cluster endpoint URL"
+  value       = local.cluster_endpoint
+}
+
+output "controlplane_nodes" {
+  description = "List of control plane node IPs"
+  value       = local.controlplane_ips
+}

--- a/infra/talos-proxmox/bootstrap/terraform/variables.tf
+++ b/infra/talos-proxmox/bootstrap/terraform/variables.tf
@@ -37,6 +37,18 @@ variable "cluster_vip" {
   default     = ""
 }
 
+variable "bootstrap_node_ip" {
+  description = "IP of the node to use for bootstrap operations (optional - uses first available control plane if not provided)"
+  type        = string
+  default     = ""
+}
+
+variable "force_kubeconfig_recreation" {
+  description = "Set to current timestamp to force kubeconfig recreation (e.g., run date +%s)"
+  type        = string
+  default     = ""
+}
+
 variable "worker_ips" {
   description = "List of worker node IPs"
   type        = list(string)

--- a/infra/talos-proxmox/bootstrap/terraform/variables.tf
+++ b/infra/talos-proxmox/bootstrap/terraform/variables.tf
@@ -4,10 +4,6 @@ variable "cluster_name" {
   default     = "homelab-k8s"
 }
 
-locals {
-  cluster_endpoint = "https://${var.controlplane_ip}:6443"
-}
-
 variable "kubernetes_version" {
   description = "Kubernetes version to use"
   type        = string
@@ -20,9 +16,25 @@ variable "talos_version" {
   default     = "v1.10.6"
 }
 
-variable "controlplane_ip" {
-  description = "IP address of the control plane node"
+variable "controlplane_ips" {
+  description = "List of control plane node IPs"
+  type        = list(string)
+  
+  validation {
+    condition     = length(var.controlplane_ips) >= 1
+    error_message = "At least one control plane IP must be provided."
+  }
+  
+  validation {
+    condition     = length(var.controlplane_ips) % 2 == 1
+    error_message = "The number of control plane nodes should be odd (1, 3, 5, etc.) for proper etcd quorum."
+  }
+}
+
+variable "cluster_vip" {
+  description = "Virtual IP for the cluster API endpoint (optional - uses first control plane IP if not provided)"
   type        = string
+  default     = ""
 }
 
 variable "worker_ips" {

--- a/infra/talos-proxmox/bootstrap/terragrunt.hcl
+++ b/infra/talos-proxmox/bootstrap/terragrunt.hcl
@@ -12,6 +12,6 @@ dependency "provision" {
 }
 
 inputs = {
-  controlplane_ip = dependency.provision.outputs.controlplane_ip
+  controlplane_ips = dependency.provision.outputs.controlplane_ips
   worker_ips      = dependency.provision.outputs.worker_ips
 }

--- a/infra/talos-proxmox/provision/terraform/env.tfvars.example
+++ b/infra/talos-proxmox/provision/terraform/env.tfvars.example
@@ -1,0 +1,40 @@
+virtual_environment={
+    password     = "<PROXMOX_PASSWORD>"
+    endpoint     = "https://<PROXMOX_HOST>:<PORT>/api2/json"
+    username     = "<PROXMOX_USER>@<realm>" #root@pam
+    node_name    = "<PROXMOX_NODE>"
+    datastore_id = "<PROXMOX_DATASTORE>"
+}
+
+project_name      = "<PROJECT_NAME>"
+priv_key_path     = "<PATH_TO_PRIVATE_KEY>"
+
+control_plane_nodes=[
+    {
+    vm_name = "<CONTROL_PLANE_VM_NAME>"
+    cpu_cores = <CPU_CORES>
+    memory_size = <MEMORY_SIZE>
+    disk_size = <DISK_SIZE>
+    ipv4_address = "<CONTROL_PLANE_IP_CIDR / dhcp>"
+    ipv4_gateway = "<GATEWAY_IP>" #optional
+    }
+]
+
+worker_nodes=[
+    {
+    vm_name = "<WORKER_VM_NAME_1>"
+    cpu_cores = <CPU_CORES>
+    memory_size = <MEMORY_SIZE>
+    disk_size = <DISK_SIZE>
+    ipv4_address = "<WORKER_IP_CIDR / dhcp>"
+    ipv4_gateway = "<GATEWAY_IP>" #optional
+    },
+    {
+    vm_name = "<WORKER_VM_NAME_2>"
+    cpu_cores = <CPU_CORES>
+    memory_size = <MEMORY_SIZE>
+    disk_size = <DISK_SIZE>
+    ipv4_address = "<WORKER_IP_CIDR / dhcp>"
+    ipv4_gateway = "<GATEWAY_IP>" #optional
+    }
+]

--- a/infra/talos-proxmox/provision/terraform/main.tf
+++ b/infra/talos-proxmox/provision/terraform/main.tf
@@ -15,23 +15,25 @@ resource "proxmox_virtual_environment_download_file" "talos_image" {
 }
 
 # Create a controlplane node
-module "talos_controlplane_01" {
+module "talos_controlplane" {
   source = "./modules/proxmox-talos-vm"
+  count  = length(var.control_plane_nodes)
 
   # VM Configuration
-  vm_name         = "talos-cp-01"
-  talos_image_id  = proxmox_virtual_environment_download_file.talos_image.id
-  pve_node_name   = "proxmox"
+  vm_name        = var.control_plane_nodes[count.index].vm_name
+  talos_image_id = proxmox_virtual_environment_download_file.talos_image.id
+  pve_node_name  = var.virtual_environment.node_name
   
   # Hardware specs
-  cpu_cores    = 2
-  memory_size  = 4096
-  disk_size    = 30
+  cpu_cores      = var.control_plane_nodes[count.index].cpu_cores
+  memory_size    = var.control_plane_nodes[count.index].memory_size
+  disk_size      = var.control_plane_nodes[count.index].disk_size
   
-  # Network configuration
-  ipv4_address  = "192.168.0.60/24"
-  ipv4_gateway           = "192.168.0.1"
-  dns_servers       = ["192.168.0.1", "1.1.1.1"]
+  # Network configuration (using DHCP for workers)
+  enable_cloud_init = true
+  dns_servers       = var.dns_config.servers
+  ipv4_address = var.control_plane_nodes[count.index].ipv4_address
+  ipv4_gateway = var.control_plane_nodes[count.index].ipv4_gateway
   
   # Optional features
   enable_tpm = true

--- a/infra/talos-proxmox/provision/terraform/main.tf
+++ b/infra/talos-proxmox/provision/terraform/main.tf
@@ -30,7 +30,8 @@ module "talos_controlplane" {
   cpu_cores      = each.value.cpu_cores
   memory_size    = each.value.memory_size
   disk_size      = each.value.disk_size
-  
+  pve_datastore_id = var.virtual_environment.datastore_id
+
   # Network configuration
   enable_cloud_init = true
   dns_servers       = var.dns_config.servers
@@ -55,6 +56,7 @@ module "talos_worker" {
   cpu_cores      = each.value.cpu_cores
   memory_size    = each.value.memory_size
   disk_size      = each.value.disk_size
+  pve_datastore_id = var.virtual_environment.datastore_id
   
   # Network configuration
   enable_cloud_init = true

--- a/infra/talos-proxmox/provision/terraform/main.tf
+++ b/infra/talos-proxmox/provision/terraform/main.tf
@@ -29,9 +29,8 @@ module "talos_controlplane_01" {
   disk_size    = 30
   
   # Network configuration
-  ip_type            = "static"
-  static_ip_address  = "192.168.0.60/24"
-  gateway           = "192.168.0.1"
+  ipv4_address  = "192.168.0.60/24"
+  ipv4_gateway           = "192.168.0.1"
   dns_servers       = ["192.168.0.1", "1.1.1.1"]
   
   # Optional features
@@ -41,22 +40,24 @@ module "talos_controlplane_01" {
 # Create worker nodes
 module "talos_worker" {
   source = "./modules/proxmox-talos-vm"
-  count  = 2
+  count  = length(var.worker_nodes)
 
   # VM Configuration
-  vm_name        = "talos-worker-${count.index + 1}"
+  vm_name        = var.worker_nodes[count.index].vm_name
   talos_image_id = proxmox_virtual_environment_download_file.talos_image.id
-  pve_node_name  = "proxmox"
+  pve_node_name  = var.virtual_environment.node_name
   
   # Hardware specs
-  cpu_cores   = 4
-  memory_size = 8192
-  disk_size   = 50
+  cpu_cores      = var.worker_nodes[count.index].cpu_cores
+  memory_size    = var.worker_nodes[count.index].memory_size
+  disk_size      = var.worker_nodes[count.index].disk_size
   
   # Network configuration (using DHCP for workers)
-  ip_type = "dhcp"
   enable_cloud_init = true
-  
+  dns_servers       = var.dns_config.servers
+  ipv4_address = var.worker_nodes[count.index].ipv4_address
+  ipv4_gateway = var.worker_nodes[count.index].ipv4_gateway
+
   # Talos specific
   node_type    = "worker"
   cluster_name = "homelab-k8s"

--- a/infra/talos-proxmox/provision/terraform/modules/proxmox-talos-vm/main.tf
+++ b/infra/talos-proxmox/provision/terraform/modules/proxmox-talos-vm/main.tf
@@ -41,12 +41,10 @@ resource "proxmox_virtual_environment_vm" "talos_vm" {
 
   initialization {
     datastore_id = var.pve_datastore_id
-    # For Talos, we don't use Proxmox cloud-init network config since Talos handles networking
-    # Only set DNS configuration via cloud-init
     ip_config {
       ipv4 {
-        address = var.static_ip_address
-        gateway = var.gateway
+        address = var.ipv4_address
+        gateway = var.ipv4_gateway
       }
     }
     dns {

--- a/infra/talos-proxmox/provision/terraform/modules/proxmox-talos-vm/variable.tf
+++ b/infra/talos-proxmox/provision/terraform/modules/proxmox-talos-vm/variable.tf
@@ -44,26 +44,16 @@ variable "pve_node_name" {
   description = "Proxmox node name"
 }
 
-variable "ip_type" {
+variable "ipv4_address" {
   type        = string
-  default     = "dhcp"
-  description = "IP configuration type: 'dhcp' or 'static'"
-  validation {
-    condition     = contains(["dhcp", "static"], var.ip_type)
-    error_message = "IP type must be either 'dhcp' or 'static'."
-  }
+  description = "IPv4 CIDR format or dhcp"
+  default = "dhcp"
 }
 
-variable "static_ip_address" {
+variable "ipv4_gateway" {
   type        = string
+  description = "IPv4 gateway. Optional if ipv4_address is 'dhcp'"
   default     = null
-  description = "Static IP address with CIDR notation (e.g., '192.168.1.100/24')"
-}
-
-variable "gateway" {
-  type        = string
-  default     = null
-  description = "Gateway IP address (required when using static IP)"
 }
 
 variable "dns_domain" {

--- a/infra/talos-proxmox/provision/terraform/modules/proxmox-talos-vm/versions.tf
+++ b/infra/talos-proxmox/provision/terraform/modules/proxmox-talos-vm/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     proxmox = {
       source  = "bpg/proxmox"
-      version = "0.81.0"
+      version = "0.82.1"
     }
   }
   required_version = ">= 1.0"

--- a/infra/talos-proxmox/provision/terraform/outputs.tf
+++ b/infra/talos-proxmox/provision/terraform/outputs.tf
@@ -1,7 +1,7 @@
 
 # Output the IP addresses
-output "controlplane_ip" {
-  value = module.talos_controlplane_01.ipv4_address
+output "controlplane_ips" {
+  value = module.talos_controlplane[*].ipv4_address
 }
 
 output "worker_ips" {

--- a/infra/talos-proxmox/provision/terraform/outputs.tf
+++ b/infra/talos-proxmox/provision/terraform/outputs.tf
@@ -1,9 +1,8 @@
-
 # Output the IP addresses
 output "controlplane_ips" {
-  value = module.talos_controlplane[*].ipv4_address
+  value = values(module.talos_controlplane)[*].ipv4_address
 }
 
 output "worker_ips" {
-  value = module.talos_worker[*].ipv4_address
+  value = values(module.talos_worker)[*].ipv4_address
 }

--- a/infra/talos-proxmox/provision/terraform/providers.tf
+++ b/infra/talos-proxmox/provision/terraform/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     proxmox = {
       source = "bpg/proxmox"
-      version = "0.81.0"
+      version = "0.82.1"
     }
   }
 }

--- a/infra/talos-proxmox/provision/terraform/variable.tf
+++ b/infra/talos-proxmox/provision/terraform/variable.tf
@@ -13,11 +13,6 @@ variable "project_name" {
     type = string
 } 
 
-variable "vm_count" {
-    type = number
-    default = 1
-}
-
 variable "priv_key_path" {
     type = string
     description = "Path to the public key file"
@@ -26,6 +21,19 @@ variable "priv_key_path" {
 
 locals {
   priv_key_content = file(pathexpand(var.priv_key_path))
+}
+
+variable "control_plane_nodes" {
+  description = "List of control plane node definitions"
+  type = list(object({
+    vm_name           = string
+    cpu_cores         = number
+    memory_size       = number
+    disk_size         = number  
+    ipv4_address      = string
+    ipv4_gateway      = optional(string)
+  }))
+  default = []
 }
 
 variable "worker_nodes" {

--- a/infra/talos-proxmox/provision/terraform/variable.tf
+++ b/infra/talos-proxmox/provision/terraform/variable.tf
@@ -27,3 +27,28 @@ variable "priv_key_path" {
 locals {
   priv_key_content = file(pathexpand(var.priv_key_path))
 }
+
+variable "worker_nodes" {
+  description = "List of worker node definitions"
+  type = list(object({
+    vm_name           = string
+    cpu_cores         = number
+    memory_size       = number
+    disk_size         = number  
+    ipv4_address      = string
+    ipv4_gateway      = optional(string)
+  }))
+  default = []
+}
+
+variable "dns_config" {
+  description = "DNS configuration for cluster nodes"
+  type = object({
+    domain  = string
+    servers = list(string)
+  })
+  default = {
+    domain  = "local"
+    servers = ["1.1.1.1", "8.8.8.8"]
+  }
+}

--- a/infra/talos-proxmox/root.hcl.example
+++ b/infra/talos-proxmox/root.hcl.example
@@ -30,6 +30,35 @@ inputs = {
         node_name    = "proxmox"
         datastore_id = "ssd-lvm"
     }
+
+    control_plane_nodes=[
+      {
+      vm_name = "cp-01"
+      cpu_cores = 4
+      memory_size = 8192
+      disk_size = 20
+      ipv4_address = "192.168.0.60/24"
+      ipv4_gateway = "192.168.0.1"
+      }
+    ]
+
+    worker_nodes=[
+      {
+      vm_name = "worker-01"
+      cpu_cores = 2
+      memory_size = 4096
+      disk_size = 20
+      ipv4_address = "dhcp"
+      },
+      {
+      vm_name = "worker-02"
+      cpu_cores = 2
+      memory_size = 4096
+      disk_size = 20
+      ipv4_address = "dhcp"
+      }
+    ]
+
     project_name      = "devops-playground"
     priv_key_path     = "~/.ssh/id_ed25519"
     cluster_name      = "devops-playground-mngmt"

--- a/scripts/requirements.yml
+++ b/scripts/requirements.yml
@@ -1,0 +1,9 @@
+
+# Ansible roles
+roles:
+  - src: istvano.microk8s
+
+# Ansible collections
+collections:
+  - name: kubernetes.core
+  - name: community.kubernetes

--- a/scripts/venv-activate.sh
+++ b/scripts/venv-activate.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Get the directory of this script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$SCRIPT_DIR/.."
+
+# Check if venv exists, if not, create it
+if [ ! -d "$ROOT_DIR/venv" ]; then
+  echo "Python virtual environment not found. Running setup..."
+  bash "$SCRIPT_DIR/venv-setup.sh"
+fi
+
+. "$ROOT_DIR/venv/bin/activate"

--- a/scripts/venv-setup.sh
+++ b/scripts/venv-setup.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# Get the directory of this script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$SCRIPT_DIR/.." 
+ 
+sudo apt update
+sudo apt install -y python3-venv curl unzip
+
+# Create a Python virtual environment in the ansible folder
+python3 -m venv $ROOT_DIR/venv
+
+# Activate the virtual environment
+source $ROOT_DIR/venv/bin/activate
+
+# Upgrade pip and install Ansible and Kubernetes Python client
+pip install --upgrade pip
+pip install ansible kubernetes
+
+# Install Ansible roles
+ansible-galaxy install -r $SCRIPT_DIR/requirements.yml
+
+# Download and install Terraform CLI in the virtualenv's bin folder
+TERRAFORM_VERSION="1.13.0"
+TERRAFORM_ZIP="terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
+TERRAFORM_URL="https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/${TERRAFORM_ZIP}"
+
+echo "Installing Terraform ${TERRAFORM_VERSION}..."
+
+curl -fsSLo /tmp/${TERRAFORM_ZIP} ${TERRAFORM_URL}
+unzip -o /tmp/${TERRAFORM_ZIP} -d ../venv/bin/
+chmod +x ../venv/bin/terraform
+rm /tmp/${TERRAFORM_ZIP}
+
+# Test Terraform install
+terraform version
+
+# Install Terragrunt
+TERRAGRUNT_VERSION="v0.86.1"
+TERRAGRUNT_BIN="terragrunt"
+TERRAGRUNT_URL="https://github.com/gruntwork-io/terragrunt/releases/download/${TERRAGRUNT_VERSION}/terragrunt_linux_amd64"
+
+echo "Installing Terragrunt ${TERRAGRUNT_VERSION}..."
+
+curl -fsSLo ../venv/bin/${TERRAGRUNT_BIN} ${TERRAGRUNT_URL}
+chmod +x ../venv/bin/${TERRAGRUNT_BIN}
+
+# Test Terragrunt install
+../venv/bin/terragrunt --version
+
+
+KUSTOMIZE_VERSION="v5.7.1"
+KUSTOMIZE_TAR="kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz"
+KUSTOMIZE_URL="https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/${KUSTOMIZE_TAR}"
+VENV_BIN="../venv/bin"   # Adjust to your venv bin folder
+
+echo "Installing kustomize ${KUSTOMIZE_VERSION}..."
+
+curl -fsSLo /tmp/${KUSTOMIZE_TAR} ${KUSTOMIZE_URL}
+
+# Extract kustomize binary from the tar.gz (it contains just one file named 'kustomize')
+tar -xzf /tmp/${KUSTOMIZE_TAR} -C /tmp/
+
+# Move binary to venv bin
+mv /tmp/kustomize ${VENV_BIN}/
+chmod +x ${VENV_BIN}/kustomize
+
+# Clean up
+rm /tmp/${KUSTOMIZE_TAR}
+
+echo "kustomize installed to ${VENV_BIN}/kustomize"
+
+
+# Deactivate the virtual environment
+deactivate
+
+echo "Virtual environment setup complete. Ansible and Terraform are installed."

--- a/scripts/venv-setup.sh
+++ b/scripts/venv-setup.sh
@@ -21,7 +21,7 @@ pip install ansible kubernetes
 ansible-galaxy install -r $SCRIPT_DIR/requirements.yml
 
 # Download and install Terraform CLI in the virtualenv's bin folder
-TERRAFORM_VERSION="1.13.0"
+TERRAFORM_VERSION="1.12.2"
 TERRAFORM_ZIP="terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
 TERRAFORM_URL="https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/${TERRAFORM_ZIP}"
 
@@ -36,7 +36,7 @@ rm /tmp/${TERRAFORM_ZIP}
 terraform version
 
 # Install Terragrunt
-TERRAGRUNT_VERSION="v0.86.1"
+TERRAGRUNT_VERSION="v0.85.0"
 TERRAGRUNT_BIN="terragrunt"
 TERRAGRUNT_URL="https://github.com/gruntwork-io/terragrunt/releases/download/${TERRAGRUNT_VERSION}/terragrunt_linux_amd64"
 


### PR DESCRIPTION
- refactor: update IP configuration variables for Talos VM
- refactor: update network configuration and worker node variables in Terraform scripts
- refactor: update control plane module to use dynamic configuration for multiple control nodes
- refactor: add .terraform.lock.hcl to .gitignore to prevent version control of lock files
- feat: add example environment configuration for Proxmox Terraform setup
- feat: add scripts for Python virtual environment setup and Ansible role installation
- fix: update proxmox provider version to 0.82.1 in Terraform configuration
- fix: terraform revert to v1.12.2
- feat: add control plane and worker nodes configuration to root.hcl.example
- feat: refactor Talos node configuration to use for_each for control plane and worker nodes
- fix: add missing pve_datastore_id assignment in control plane and worker node configurations
- feat: update control plane configuration to support multiple control nodes provided as input variable
- feat: bootstrap new nodes added to cluster and kubeconfig refresh script
